### PR TITLE
Fix documentation naming issue

### DIFF
--- a/examples/home-in-on-points.md
+++ b/examples/home-in-on-points.md
@@ -28,7 +28,7 @@ The complete code for the game to work can be found [here](https://github.com/fm
 
 ```javascript
 <head>
-   <script lang="text/javascript" src="https://unpkg.com/simple-web-serial@latest/dist/simple-serial.min.js"></script>
+   <script lang="text/javascript" src="https://unpkg.com/simple-web-serial@latest/dist/simple-web-serial.min.js"></script>
 </head>
 
 <div id="horizontal"></div>

--- a/installation/javascript.md
+++ b/installation/javascript.md
@@ -9,7 +9,7 @@ description: How to set up the JavaScript part of the SimpleWebSerial library.
 This is the easiest method to get you started immediately. Just include the script tag inside the `<head>` of your document and you're good to go:
 
 ```markup
-<script lang="text/javascript" src="https://unpkg.com/simple-web-serial@latest/dist/simple-serial.min.js"></script>
+<script lang="text/javascript" src="https://unpkg.com/simple-web-serial@latest/dist/simple-web-serial.min.js"></script>
 ```
 
 That's it! Either [set-up the Arduino Library](arduino.md) as well, or take a look [how to use the JavaScript library](../usage/javascript.md).
@@ -23,7 +23,7 @@ npm i simple-web-serial
 And include it in your project either by using a script tag:
 
 ```markup
-<script lang="text/javascript" src="../node_modules/simple-web-serial/dist/simple-serial.min.js">
+<script lang="text/javascript" src="../node_modules/simple-web-serial/dist/simple-web-serial.min.js">
 ```
 
 or with a bundler like webpack or vite:


### PR DESCRIPTION
Fix issue where package was still references as "simple-serial" from way back when. Correct naming is "simple-web-serial". Closes https://github.com/fmgrafikdesign/SimpleWebSerialJS/issues/5